### PR TITLE
Hyrax 285

### DIFF
--- a/NCArray.cc
+++ b/NCArray.cc
@@ -175,8 +175,13 @@ void NCArray::do_cardinal_array_read(int ncid, int varid, nc_type datatype,
                     errstat = nc_get_vars(ncid, varid, cor, edg, step, &values[0]);
                 else
                     errstat = nc_get_vara(ncid, varid, cor, edg, &values[0]);
-                if (errstat != NC_NOERR)
-                    throw Error(errstat, string("Could not get the value for variable '") + name() + string("' (NCArray::do_cardinal_array_read)"));
+                if (errstat != NC_NOERR){
+                	ostringstream oss;
+                	oss << "NCArray::do_cardinal_array_read() - Could not get the value for Array variable '" << name() << "'.";
+                	oss << " dimensions: " << dimensions(true);
+                	oss << " nc_get_vara() errstat: " << errstat;
+                    throw Error(errstat, oss.str());
+                }
                 // Do not set has_values to true here because the 'true' state
                 // indicates that the values for an entire compound have been
                 // read.
@@ -481,7 +486,15 @@ bool NCArray::read()
     size_t edg[MAX_NC_DIMS];      /* edges of hyper-cube */
     ptrdiff_t step[MAX_NC_DIMS];  /* stride of hyper-cube */
     bool has_stride;
+    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
+		cor[i] = edg[i] = step[i] = 0;
+    }
     long nels = format_constraint(cor, step, edg, &has_stride);
+    ostringstream oss;
+    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
+    	oss << cor[i] <<  ", " << edg[i] << ", " << step[i] << endl;
+    }
+    BESDEBUG("nc", "NCArray::read() - corners, edges, stride" << endl << oss.str() << endl);
 
     vector<char> values;
     do_array_read(ncid, varid, datatype, values, false /*has_values*/, 0 /*values_offset*/,

--- a/NCArray.cc
+++ b/NCArray.cc
@@ -486,6 +486,8 @@ bool NCArray::read()
     size_t edg[MAX_NC_DIMS];      /* edges of hyper-cube */
     ptrdiff_t step[MAX_NC_DIMS];  /* stride of hyper-cube */
     bool has_stride;
+#if 0
+
     /**
      * Zero the constraint should not be required, but when there
      * are mismatches in dimensionality it caues trouble.
@@ -493,16 +495,18 @@ bool NCArray::read()
      * Zeroing the array may be the right thing, but in this
      * case I only enable it as a bugging step.
      */
-//    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
-//		cor[i] = edg[i] = step[i] = 0;
-//    }
+    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
+        cor[i] = edg[i] = step[i] = 0;
+     }
+#endif
     long nels = format_constraint(cor, step, edg, &has_stride);
+#if 0
     ostringstream oss;
     for(unsigned int i=0; i<MAX_NC_DIMS; i++){
     	oss << cor[i] <<  ", " << edg[i] << ", " << step[i] << endl;
     }
     BESDEBUG("nc", "NCArray::read() - corners, edges, stride" << endl << oss.str() << endl);
-
+#endif
     vector<char> values;
     do_array_read(ncid, varid, datatype, values, false /*has_values*/, 0 /*values_offset*/,
             nels, cor, edg, step, has_stride);

--- a/NCArray.cc
+++ b/NCArray.cc
@@ -486,9 +486,16 @@ bool NCArray::read()
     size_t edg[MAX_NC_DIMS];      /* edges of hyper-cube */
     ptrdiff_t step[MAX_NC_DIMS];  /* stride of hyper-cube */
     bool has_stride;
-    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
-		cor[i] = edg[i] = step[i] = 0;
-    }
+    /**
+     * Zero the constraint should not be required, but when there
+     * are mismatches in dimensionality it caues trouble.
+     * Which is a good thing because it shows a broken thing.
+     * Zeroing the array may be the right thing, but in this
+     * case I only enable it as a bugging step.
+     */
+//    for(unsigned int i=0; i<MAX_NC_DIMS; i++){
+//		cor[i] = edg[i] = step[i] = 0;
+//    }
     long nels = format_constraint(cor, step, edg, &has_stride);
     ostringstream oss;
     for(unsigned int i=0; i<MAX_NC_DIMS; i++){

--- a/ncdds.cc
+++ b/ncdds.cc
@@ -53,6 +53,7 @@
 #include <DDS.h>
 #include <mime_util.h>
 #include <util.h>
+#include <BESDebug.h>
 
 #include "NCRequestHandler.h"
 #include "nc_util.h"
@@ -408,9 +409,19 @@ static bool find_matching_coordinate_variable(int ncid, int var,
             if (errstat != NC_NOERR)
                 throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(varid));
 
-            // Map arrays can only be one dimensioanl in DAP2 so if we are here
-            // and this thing has more than one dimension it's not a DAP2 Grid
+            // Map arrays can only be one dimensional in DAP2 so if we are here
+            // and this thing has more than one dimension it's not a valid
+            // Map array for a DAP2 Grid so return false.
             if(candidate_ndims!=1){
+                char array_name[MAX_NC_NAME];
+            	errstat = nc_inq_varname(ncid, var, array_name);
+                if (errstat != NC_NOERR)
+                    throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(var));
+
+               BESDEBUG("nc", "ncdds.c - find_matching_coordinate_variable() The array '" << array_name << "' is not a grid because the "
+                		"candidate Map array '" << candidate_name << " has " <<
+						candidate_ndims << " dimensions and DAP2 Map arrays must have "
+								"a single dimension" << endl);
             	return false;
             }
 

--- a/ncdds.cc
+++ b/ncdds.cc
@@ -399,6 +399,21 @@ static bool find_matching_coordinate_variable(int ncid, int var,
                 throw Error(msg);
             }
 
+            char candidate_name[MAX_NC_NAME];
+            nc_type candidate_nctype;
+            int candidate_ndims;
+            int candidate_dim_ids[MAX_VAR_DIMS];
+
+            int errstat = nc_inq_var(ncid, varid, candidate_name, &candidate_nctype, &candidate_ndims, candidate_dim_ids, (int *) 0);
+            if (errstat != NC_NOERR)
+                throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(varid));
+
+            // Map arrays can only be one dimensioanl in DAP2 so if we are here
+            // and this thing has more than one dimension it's not a DAP2 Grid
+            if(candidate_ndims!=1){
+            	return false;
+            }
+
             return true;
         }
     }

--- a/ncdds.cc
+++ b/ncdds.cc
@@ -363,72 +363,73 @@ static BaseType *build_user_defined(int ncid, int varid, nc_type xtype, const st
      at (only) all the shared dimensions?
  */
 static bool find_matching_coordinate_variable(int ncid, int var,
-        char dimname[], size_t dim_sz, nc_type *match_type)
+		char dimname[], size_t dim_sz, nc_type *match_type)
 {
-    // For netCDF, a Grid's Map must be a netCDF dimension
-    int id;
-    // get the id matching the name.
-    int status = nc_inq_dimid(ncid, dimname, &id);
-    if (status == NC_NOERR) {
-        // get the length, the name was matched above
-        size_t length;
-        status = nc_inq_dimlen(ncid, id, &length);
-        if (status != NC_NOERR) {
-            string msg = "netcdf 3: could not get size for dimension ";
-            msg += long_to_string(id);
-            msg += " in variable ";
-            msg += string(dimname);
-            throw Error(msg);
-        }
-        if (length == dim_sz) {
-            // Both the name and size match and it's a dimension, so we've
-            // found our 'matching coordinate variable'. To get the type,
-            // Must find the variable with the name that matches the dimension.
-            int varid = -1;
-            status = nc_inq_varid(ncid, dimname, &varid);
-            // A variable cannot be its own coordinate variable.
-            // The unlimited dimension does not correspond to a variable,
-            // hence the status error is means the named thing is not a
-            // coordinate; it's not an error as far as the handler is concerned.
-            if (var == varid || status != NC_NOERR)
-                return false;
+	// For netCDF, a Grid's Map must be a netCDF dimension
+	int id;
+	// get the id matching the name.
+	int status = nc_inq_dimid(ncid, dimname, &id);
+	if (status == NC_NOERR) {
+		// get the length, the name was matched above
+		size_t length;
+		status = nc_inq_dimlen(ncid, id, &length);
+		if (status != NC_NOERR) {
+			string msg = "netcdf 3: could not get size for dimension ";
+			msg += long_to_string(id);
+			msg += " in variable ";
+			msg += string(dimname);
+			throw Error(msg);
+		}
+		if (length == dim_sz) {
+			// Both the name and size match and it's a dimension, so we've
+			// found our 'matching coordinate variable'. To get the type,
+			// Must find the variable with the name that matches the dimension.
+			int varid = -1;
+			status = nc_inq_varid(ncid, dimname, &varid);
+			// A variable cannot be its own coordinate variable.
+			// The unlimited dimension does not correspond to a variable,
+			// hence the status error is means the named thing is not a
+			// coordinate; it's not an error as far as the handler is concerned.
+			if (var == varid || status != NC_NOERR)
+				return false;
 
-            status = nc_inq_vartype(ncid, varid, match_type);
-            if (status != NC_NOERR) {
-                string msg = "netcdf 3: could not get type variable ";
-                msg += string(dimname);
-                throw Error(msg);
-            }
+			status = nc_inq_vartype(ncid, varid, match_type);
+			if (status != NC_NOERR) {
+				string msg = "netcdf 3: could not get type variable ";
+				msg += string(dimname);
+				throw Error(msg);
+			}
 
-            char candidate_name[MAX_NC_NAME];
-            nc_type candidate_nctype;
-            int candidate_ndims;
-            int candidate_dim_ids[MAX_VAR_DIMS];
+			char candidate_name[MAX_NC_NAME];
+			nc_type candidate_nctype;
+			int candidate_ndims;
+			int candidate_dim_ids[MAX_VAR_DIMS];
 
-            int errstat = nc_inq_var(ncid, varid, candidate_name, &candidate_nctype, &candidate_ndims, candidate_dim_ids, (int *) 0);
-            if (errstat != NC_NOERR)
-                throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(varid));
+			int errstat = nc_inq_var(ncid, varid, candidate_name, &candidate_nctype, &candidate_ndims, candidate_dim_ids, (int *) 0);
+			if (errstat != NC_NOERR)
+				throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(varid));
 
-            // Map arrays can only be one dimensional in DAP2 so if we are here
-            // and this thing has more than one dimension it's not a valid
-            // Map array for a DAP2 Grid so return false.
-            if(candidate_ndims!=1){
-                char array_name[MAX_NC_NAME];
-            	errstat = nc_inq_varname(ncid, var, array_name);
-                if (errstat != NC_NOERR)
-                    throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(var));
+			// Map arrays can only be one dimensional in DAP2 so if we are here
+			// and this thing has more than one dimension it's not a valid
+			// Map array for a DAP2 Grid so return false.
+			if(candidate_ndims!=1){
+				char array_name[MAX_NC_NAME];
+				errstat = nc_inq_varname(ncid, var, array_name);
+				if (errstat != NC_NOERR)
+					throw Error("netcdf: could not get name or dimension number for variable " + long_to_string(var));
 
-               BESDEBUG("nc", "ncdds.c - find_matching_coordinate_variable() The array '" << array_name << "' is not a grid because the "
-                		"candidate Map array '" << candidate_name << " has " <<
+				BESDEBUG("nc", "ncdds.c - find_matching_coordinate_variable() The array '"
+						<< array_name << "' is not a grid because the "
+						"candidate Map array '" << candidate_name << " has " <<
 						candidate_ndims << " dimensions and DAP2 Map arrays must have "
-								"a single dimension" << endl);
-            	return false;
-            }
+						"a single dimension" << endl);
+				return false;
+			}
 
-            return true;
-        }
-    }
-    return false;
+			return true;
+		}
+	}
+	return false;
 }
 
 /** Is the variable a DAP Grid?


### PR DESCRIPTION
1. Added a qc  test to the` find_matching_coordinate_variable()` function which is utilized by the `is_grid()` function in `ncdds.cc` which checks that the candidate Map arrays are all one dimensional.
1. Various debugging instrumentation.
1. I `#if 0`'d the code that I added to initialize to zero the corner, edge, and stride arrays used to subset using the netCDF-C API because the fact that they were not initialized exposed this bug. Otherwise it would have silently taken the first inner dimension of the 2D map array.
